### PR TITLE
Add /chat route

### DIFF
--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -5,3 +5,5 @@ edition = "2021"
 
 [dependencies]
 miniserve = { path = "../miniserve" }
+serde = { version = "1.0.204", features = ["derive"] }
+serde_json = "1.0.121"

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -1,10 +1,32 @@
-use miniserve::{Content, Request, Response};
+use miniserve::{http::StatusCode, Content, Request, Response};
+use serde::{Deserialize, Serialize};
 
 fn index(_req: Request) -> Response {
     let content = include_str!("../index.html").to_string();
     Ok(Content::Html(content))
 }
 
+#[derive(Serialize, Deserialize)]
+struct Messages {
+    messages: Vec<String>,
+}
+
+fn chat(req: Request) -> Response {
+    let Request::Post(body) = req else {
+        return Err(StatusCode::METHOD_NOT_ALLOWED);
+    };
+    let Ok(mut messages) = serde_json::from_str::<Messages>(&body) else {
+        return Err(StatusCode::INTERNAL_SERVER_ERROR);
+    };
+    messages
+        .messages
+        .push("And how does that make you feel?".into());
+    Ok(Content::Json(serde_json::to_string(&messages).unwrap()))
+}
+
 fn main() {
-    miniserve::Server::new().route("/", index).run()
+    miniserve::Server::new()
+        .route("/", index)
+        .route("/chat", chat)
+        .run()
 }


### PR DESCRIPTION
This is the reference solution for adding the`/chat` route. 

Note: due to a merge conflict, this PR is a hard reset to the reference solution, and may have overwritten your previous changes.